### PR TITLE
Ensure having `;`  at the end of queries

### DIFF
--- a/digdaglog2sql/td_op.py
+++ b/digdaglog2sql/td_op.py
@@ -8,7 +8,8 @@ def upper_repl(match, op):
 def extract_td_sql(input: str, drop_cdp_db: bool = False):
     pat = re.compile(
         r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ \+\d{4} \[INFO\]"
-        r" \([\w\S]+?\) [\w\.]+?\$TdOperator:.+?:\n(.*?)(?=;?\n+\d{4}-\d{2}-\d{2})",
+        r" \([\w\S]+?\) [\w\.]+?\$TdOperator:.+?:\n(.*?)"
+        r"(?=(?:;?\n+\d{4}-\d{2}-\d{2})|(?:\Z))",
         re.DOTALL,
     )
     pat2 = re.compile(
@@ -24,7 +25,7 @@ def extract_td_sql(input: str, drop_cdp_db: bool = False):
         r"Creating TD (database|table) (.+)"
     )
 
-    data = re.sub(pat, r"\1;", input)
+    data = re.sub(pat, r"\1\n;", input)
     data = re.sub(pat2, r"ALTER TABLE \1.\2 RENAME TO \1.\3;", data)
     data = re.sub(pat3, lambda match: upper_repl(match, "DROP"), data)
     data = re.sub(pat4, lambda match: upper_repl(match, "CREATE"), data)

--- a/tests/test_digdaglog2sql.py
+++ b/tests/test_digdaglog2sql.py
@@ -38,7 +38,8 @@ from (
 ALTER TABLE tbl1.cdp_tmp_behavior_behavior_1 RENAME TO tbl1.behavior_behavior_1;
 DROP TABLE IF EXISTS tmp_customers;
 CREATE TABLE tmp_customers (customer_id VARCHAR)
-  WITH (bucketed_on = array['customer_id'], bucket_count = 512);
+  WITH (bucketed_on = array['customer_id'], bucket_count = 512)
+;
 INSERT INTO TABLE `tmp_customers`
 select
     m.customer_id,
@@ -51,7 +52,53 @@ from (
       td_last(`email`, time) as `email`
     from `source_tbl`.`users`
     group by 1
-  ) m"""
+  ) m
+;"""
+
+    assert extract_sql(log) == expected_sql
+
+
+def test_extractg_sql_with_comment():
+    log = """2020-11-11 01:29:29.949 +0000 [INFO] (0538@[10778:db1]+customers) io.digdag.core.agent.OperatorManager: td>: 
+2020-11-11 01:29:30.489 +0000 [INFO] (0538@[10778:db1]+customers) io.digdag.standards.operator.td.TdOperatorFactory$TdOperator: Started presto job id=884667004:
+-- project_name: db1
+-- workflow_name: audience
+-- task_name: +customers
+INSERT INTO "tmp_customers"
+-- workflow task: +customers
+select
+    m.customer_id,
+    m.`td_client_id`,
+    m.`email`
+from (
+    select
+      customer_id,
+      td_last(`td_client_id`, time) as `td_client_id`,
+      td_last(`email`, time) as `email`
+    from `source_tbl`.`users`
+    group by 1
+  ) m
+-- set session join_distribution_type = 'PARTITIONED'"""  # noqa
+
+    expected_sql = """-- project_name: db1
+-- workflow_name: audience
+-- task_name: +customers
+INSERT INTO "tmp_customers"
+-- workflow task: +customers
+select
+    m.customer_id,
+    m.`td_client_id`,
+    m.`email`
+from (
+    select
+      customer_id,
+      td_last(`td_client_id`, time) as `td_client_id`,
+      td_last(`email`, time) as `email`
+    from `source_tbl`.`users`
+    group by 1
+  ) m
+-- set session join_distribution_type = 'PARTITIONED'
+;"""  # noqa
 
     assert extract_sql(log) == expected_sql
 
@@ -98,12 +145,12 @@ ALTER TABLE tbl1.cdp_tmp_behavior_behavior_1 RENAME TO tbl1.behavior_behavior_1;
 
 DROP TABLE IF EXISTS tmp_customers;
 CREATE TABLE tmp_customers (customer_id VARCHAR)
-  WITH (bucketed_on = array['customer_id'], bucket_count = 512);
+  WITH (bucketed_on = array['customer_id'], bucket_count = 512)
+;
 
 
 2022-04-30 07:00:11.215 +0000 [INFO] (0420@[1:tbl1:76144781:411862721]+customers) io.digdag.core.agent.OperatorManager: td>: 
 
-2022-04-30 07:00:12.138 +0000 [INFO] (0634@[1:tbl1:76144781:411862721]+customers) io.digdag.standards.operator.td.TdOperatorFactory$TdOperator: Started hive job id=1372905245:
 INSERT INTO TABLE `tmp_customers`
 select
     m.customer_id,
@@ -116,6 +163,7 @@ from (
       td_last(`email`, time) as `email`
     from `source_tbl`.`users`
     group by 1
-  ) m"""  # noqa
+  ) m
+;"""  # noqa
 
     assert extract_td_sql(log) == expected_output


### PR DESCRIPTION
When the last line of a query is a comment, `;` is commented out so that it won't be separated.

This patch ensures to have `;` at the end of lines.